### PR TITLE
Bash prompt works with newest git and shows branch only when found

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,11 +233,23 @@ git config --global color.branch auto
 
 #### Branch name and merge status in bash prompt (should go to local or global bash profile)
 ```shell
-function parse_git_dirty {
-  [[ $(git status 2> /dev/null | tail -n1) != "nothing to commit, working directory clean" ]] && echo "*"
+function parse_git_dirty () {
+  [[ $(git status 2> /dev/null | tail -1) != "nothing to commit, working tree clean" ]] && echo "*"
 }
-function parse_git_branch {
-  git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/[\1$(parse_git_dirty)]/"
+
+function parse_git_branch () {
+  git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
 }
-export PS1='\u@\h \[\033[0;36m\]\w \[\033[0;32m\]$(parse_git_branch)\[\033[0m\]$ '
+
+function show_git_prompt () {
+  git branch 2>/dev/null 1>&2 && echo -e "\033[0;32m$(parse_git_branch)\033[0m "
+}
+
+if [[ -n $(type -t git) ]] ; then
+  PS1="\$(show_git_prompt)"
+else
+  PS1=
+fi
+
+export PS1="\u@\h \[\033[0;36m\]\w $PS1$ "
 ```


### PR DESCRIPTION
I was inspired by your cheatsheet and made some improvements to the bash prompt definition while working on my own [bash prompt with git integration](https://gist.github.com/specious/8244801).

Now it detects presence of git and doesn't show the branch unless you're in a git repository. The verbatim output of `git status` must have changed at some point, because now it says `nothing to commit, working tree clean`.